### PR TITLE
Bug Fixes & Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Configure your site_path and port and you are good to go.  Your gulpfile.js shou
 /* !!!! CONFIGURE !!!!
 ================================ */
 var options = {};
+options.user = 'yourusername';
 options.port = 8888;
 options.site_path = '/your/full/site/path'; // something like /Users/username/sites/mymampsite 
 
@@ -23,16 +24,18 @@ var gulp = require('gulp');
 var mamp = require('gulp-mamp');
 
 gulp.task('config', function(cb){
-  mamp(options, 'config', cb);
+    mamp(options, 'config', cb);
 });
 
 gulp.task('start', function(cb){
-  mamp(options, 'start', cb);
+    mamp(options, 'start', cb);
 });
 
 gulp.task('stop', function(cb){
-  mamp(options, 'stop', cb);
+    mamp(options, 'stop', cb);
 });
+
+gulp.task('mamp', ['config', 'start']);
 ```
 
 ### Getting Started (and Stopped!)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ gulp.task('mamp', ['config', 'start']);
 ### Getting Started (and Stopped!)
 Once you have your gulpfile.js file configged, you can run the following commands to config, start and stop MAMP.
 ```
-gulp config
-gulp start
+gulp mamp
 gulp stop
 ```

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,3 +20,5 @@ gulp.task('start', function(cb){
 gulp.task('stop', function(cb){
 	mamp(options, 'stop', cb);
 });
+
+gulp.task('mamp', ['config', 'start']);

--- a/httpd.conf-template
+++ b/httpd.conf-template
@@ -45,7 +45,7 @@ PidFile logs/httpd.pid
 # prevent Apache from glomming onto all bound IP addresses.
 #
 #Listen 12.34.56.78:80
-Listen 8888
+Listen $port
 
 #
 # Dynamic Shared Object (DSO) Support
@@ -179,7 +179,7 @@ ServerAdmin you@example.com
 #
 # If your host doesn't have a registered DNS name, enter its IP address here.
 #
-ServerName localhost:8888
+ServerName localhost:$port
 
 #
 # DocumentRoot: The directory out of which you will serve your

--- a/index.js
+++ b/index.js
@@ -4,6 +4,17 @@ var exec = require('child_process').exec;
 
 module.exports = function (options, task, cb) {
 
+	function sudo(port) {
+
+		var val = '';;
+
+		if(port === 80) {
+			val = 'sudo ';
+		}
+
+		return val;
+	}
+
 	if(task == 'config'){
 		var command = "sed -e 's%$user%" + options.user + "%g' -e 's%$path%" + options.site_path + "%g' -e 's%$port%" + options.port + "%g' node_modules/gulp-mamp/httpd.conf-template > /Applications/MAMP/conf/apache/httpd.conf";
 		exec(command, function(err) {
@@ -14,7 +25,7 @@ module.exports = function (options, task, cb) {
 	}
 
 	if(task == 'start'){
-		var command = '/Applications/MAMP/bin/start.sh'
+		var command = sudo(options.port) + '/Applications/MAMP/bin/start.sh'
 		exec(command, function(err) {
 	    if (err) return cb(err); // return error
 	    console.log('Starting mamp server at http://localhost:' + options.port);
@@ -23,7 +34,7 @@ module.exports = function (options, task, cb) {
 	}
 
 	if(task == 'stop'){
-		var command = '/Applications/MAMP/bin/stop.sh'
+		var command =  sudo(options.port) + '/Applications/MAMP/bin/stop.sh'
 		exec(command, function(err) {
 	    if (err) return cb(err); // return error
 	    console.log('Stopping mamp server');


### PR DESCRIPTION
- When using this project MAMP defaulted to port :8888, so I fixed that by adding $port to the httpd.conf-template
- I like to have port :80 as an option, so I added a sudo command to the index.js file when starting and stopping.
- I was getting tired of typing gulp config and gulp start separately, so I added another task that combined the two.
- The README.md was out of date, so I updated and added my changes.
